### PR TITLE
docs: view blacklist document and CLI command

### DIFF
--- a/docs/node/daemon/config/settings.mdx
+++ b/docs/node/daemon/config/settings.mdx
@@ -121,7 +121,31 @@ The peer blacklisting functionality provides operators with tools to manage prob
 
 - `p2p.blacklist.auto_blacklist_on_max_retries`: Automatically blacklist peers that exhaust connection retries (default: `true`). When a peer fails to connect after the maximum number of retry attempts, it will be automatically blacklisted to prevent further connection attempts and resource waste.
 
-- `p2p.blacklist.auto_blacklist_duration`: Duration to blacklist peers that exhaust connection retries (default: `1h`). Set to `0` for permanent blacklisting. This setting only applies to automatically blacklisted peers; manually blacklisted peers can be configured with custom durations via CLI commands.
+- `p2p.blacklist.auto_blacklist_duration`: Duration in nanoseconds to blacklist peers that exhaust connection retries (default: `3600000000000` = 1 hour). Set to `0` for permanent blacklisting. This setting only applies to automatically blacklisted peers; manually blacklisted peers can be configured with custom durations via CLI commands.
+
+Example configurations:
+
+```toml title=config.toml
+# Default temporary blacklisting (1 hour = 3,600,000,000,000 nanoseconds)
+[p2p.blacklist]
+enable = true
+auto_blacklist_on_max_retries = true
+auto_blacklist_duration = 3600000000000
+```
+
+```toml title=config.toml
+# Permanent blacklisting
+[p2p.blacklist]
+enable = true
+auto_blacklist_on_max_retries = true
+auto_blacklist_duration = 0
+```
+
+Common duration values in nanoseconds:
+- 1 minute = `60000000000`
+- 30 minutes = `1800000000000`
+- 1 hour = `3600000000000`
+- 24 hours = `86400000000000`
 
 ##### Automatic Blacklisting Behavior
 

--- a/docs/node/daemon/config/settings.mdx
+++ b/docs/node/daemon/config/settings.mdx
@@ -113,6 +113,33 @@ This section outlines configurations for the P2P service, which manages peer-to-
 
 - `p2p.target_connections`: Specifies the desired number of peer connections. The node will aim to maintain this number by establishing new connections or disconnecting from existing ones.
 
+#### Peer Blacklisting
+
+The peer blacklisting functionality provides operators with tools to manage problematic peers and improve network stability:
+
+- `p2p.blacklist.enable`: Enable peer blacklisting functionality (default: `true`). When enabled, operators can manually blacklist peers using CLI commands, and the system can automatically blacklist peers based on connection behavior.
+
+- `p2p.blacklist.auto_blacklist_on_max_retries`: Automatically blacklist peers that exhaust connection retries (default: `true`). When a peer fails to connect after the maximum number of retry attempts, it will be automatically blacklisted to prevent further connection attempts and resource waste.
+
+- `p2p.blacklist.auto_blacklist_duration`: Duration to blacklist peers that exhaust connection retries (default: `1h`). Set to `0` for permanent blacklisting. This setting only applies to automatically blacklisted peers; manually blacklisted peers can be configured with custom durations via CLI commands.
+
+##### Automatic Blacklisting Behavior
+
+When `auto_blacklist_on_max_retries` is enabled, peers that exhaust the maximum connection retry attempts (typically 500 attempts) are automatically blacklisted with the reason "connection_exhaustion". This prevents:
+
+- **Resource waste** from repeatedly attempting failed connections
+- **Network instability** caused by persistent connection failures  
+- **Rediscovery loops** where peers are removed but rediscovered through PEX
+
+The automatic blacklisting uses a temporary duration (default 1 hour) rather than permanent blacklisting, allowing problematic peers to be reconsidered after a cooling-off period. Operators can adjust this duration or set it to `0` for permanent automatic blacklisting.
+
+##### Operational Considerations
+
+- **Persistence**: Blacklist data is automatically persisted across node restarts and survives configuration changes
+- **Priority**: Blacklisted peers are prevented from connecting regardless of whitelist status
+- **Monitoring**: Use `kwild blacklist list` to monitor both manual and automatic blacklist entries
+- **Management**: Use the [`kwild blacklist`](/docs/ref/kwild/blacklist) commands to manually manage the blacklist
+
 ### Consensus
 
 The Consensus configuration allows fine-tuning of the Roadrunner consensus protocol for the Kwil node. Adjusting these settings impacts block production rates, network usage, and catch-up times.

--- a/docs/node/reference/blacklist/add.mdx
+++ b/docs/node/reference/blacklist/add.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 1
+sidebar_label: "add"
+id: "kwild-blacklist-add"
+title: "kwild blacklist add"
+description: "Add a peer to the node's blacklist"
+slug: /ref/kwild/blacklist/add
+---
+
+## kwild blacklist add
+
+Add a peer to the node's blacklist
+
+### Synopsis
+
+Add a node to the node's blacklist with an optional reason and duration. The nodeID must be in the format HEX#secp256k1 or HEX#ed25519.
+
+Blacklisted peers are prevented from connecting to your node and will be disconnected if currently connected. Blacklist entries are automatically persisted across node restarts.
+
+```
+kwild blacklist add <nodeID> [flags]
+```
+
+### Examples
+
+```
+# Add a peer permanently to the blacklist
+kwild blacklist add 0226b3ff29216dac187cea393f8af685ad419ac9644e55dce83d145c8b1af213bd#secp256k1
+
+# Add a peer with a reason
+kwild blacklist add 0226b3ff29216dac187cea393f8af685ad419ac9644e55dce83d145c8b1af213bd#secp256k1 --reason="malicious behavior"
+
+# Add a peer temporarily for 1 hour
+kwild blacklist add 0226b3ff29216dac187cea393f8af685ad419ac9644e55dce83d145c8b1af213bd#secp256k1 --reason="connection issues" --duration="1h"
+```
+
+### Options
+
+```
+      --duration string   duration to blacklist the peer (e.g., "1h", "30m", "24h"). Leave empty for permanent blacklisting
+  -h, --help              help for add
+      --output string     the format for command output - either 'text' or 'json' (default "text")
+      --reason string     reason for blacklisting the peer
+```
+
+### Options inherited from parent commands
+
+```
+  -r, --root string   root directory (default "~/.kwild")
+```
+
+### Duration Format
+
+The duration flag accepts Go duration format:
+- `1h` - 1 hour
+- `30m` - 30 minutes  
+- `24h` - 24 hours
+- `2h30m` - 2 hours and 30 minutes
+
+Leave the duration empty or set to `0` for permanent blacklisting.
+
+### SEE ALSO
+
+* [kwild blacklist](/docs/ref/kwild/blacklist)	 - Manage a node's peer blacklist
+* [kwild blacklist list](/docs/ref/kwild/blacklist/list)	 - List blacklisted peers
+* [kwild blacklist remove](/docs/ref/kwild/blacklist/remove)	 - Remove a peer from the blacklist

--- a/docs/node/reference/blacklist/index.md
+++ b/docs/node/reference/blacklist/index.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 98
+sidebar_label: "blacklist"
+id: "kwild-blacklist"
+title: "kwild blacklist"
+description: "Manage a node's peer blacklist"
+slug: /ref/kwild/blacklist
+---
+
+## kwild blacklist
+
+Manage a node's peer blacklist
+
+### Synopsis
+
+The blacklist command allows you to manage the node's peer blacklist, including adding nodes, removing nodes, and listing blacklisted nodes.
+
+Peer blacklisting provides operators with control over problematic peers that may cause network issues or waste resources. Blacklisted peers are prevented from connecting to your node regardless of whitelist status.
+
+Blacklist data is automatically persisted across node restarts and survives configuration changes.
+
+### Options
+
+```
+  -h, --help            help for blacklist
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+  -r, --root string   root directory (default "~/.kwild")
+```
+
+### SEE ALSO
+
+* [kwild](/docs/ref/kwild)	 - Kwil daemon
+* [kwild blacklist add](/docs/ref/kwild/blacklist/add)	 - Add a peer to the node's blacklist
+* [kwild blacklist list](/docs/ref/kwild/blacklist/list)	 - List blacklisted peers
+* [kwild blacklist remove](/docs/ref/kwild/blacklist/remove)	 - Remove a peer from the blacklist

--- a/docs/node/reference/blacklist/list.mdx
+++ b/docs/node/reference/blacklist/list.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 2
+sidebar_label: "list"
+id: "kwild-blacklist-list"
+title: "kwild blacklist list"
+description: "List blacklisted peers"
+slug: /ref/kwild/blacklist/list
+---
+
+## kwild blacklist list
+
+List blacklisted peers
+
+### Synopsis
+
+List all peers currently in the node's blacklist. This includes both manually blacklisted peers and automatically blacklisted peers (if auto-blacklisting is enabled).
+
+The output shows the peer ID, blacklist reason, when it was blacklisted, whether it's permanent or temporary, and the expiration time for temporary entries.
+
+```
+kwild blacklist list [flags]
+```
+
+### Examples
+
+```
+# List all blacklisted peers in text format
+kwild blacklist list
+
+# List all blacklisted peers in JSON format
+kwild blacklist list --output json
+```
+
+### Options
+
+```
+  -h, --help            help for list
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+  -r, --root string   root directory (default "~/.kwild")
+```
+
+### Output Format
+
+**Text Output:**
+The text format displays a table with the following columns:
+- **Peer ID**: The full peer identifier (pubkey#keytype)
+- **Reason**: Why the peer was blacklisted
+- **Blacklisted At**: When the peer was added to the blacklist
+- **Type**: "Permanent" or "Temporary"
+- **Expires At**: Expiration time (only for temporary entries)
+
+**JSON Output:**
+The JSON format provides structured data with the same information, suitable for programmatic processing.
+
+### SEE ALSO
+
+* [kwild blacklist](/docs/ref/kwild/blacklist)	 - Manage a node's peer blacklist
+* [kwild blacklist add](/docs/ref/kwild/blacklist/add)	 - Add a peer to the node's blacklist
+* [kwild blacklist remove](/docs/ref/kwild/blacklist/remove)	 - Remove a peer from the blacklist

--- a/docs/node/reference/blacklist/remove.mdx
+++ b/docs/node/reference/blacklist/remove.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_position: 3
+sidebar_label: "remove"
+id: "kwild-blacklist-remove"
+title: "kwild blacklist remove"
+description: "Remove a peer from the blacklist"
+slug: /ref/kwild/blacklist/remove
+---
+
+## kwild blacklist remove
+
+Remove a peer from the blacklist
+
+### Synopsis
+
+Remove a node from the node's blacklist. The nodeID must be in the format HEX#secp256k1 or HEX#ed25519.
+
+Once removed, the peer will be allowed to connect to your node again (subject to other connection policies like whitelisting in private mode).
+
+```
+kwild blacklist remove <nodeID> [flags]
+```
+
+### Examples
+
+```
+# Remove a peer from the blacklist
+kwild blacklist remove 0226b3ff29216dac187cea393f8af685ad419ac9644e55dce83d145c8b1af213bd#secp256k1
+
+# Remove a peer and show output in JSON format
+kwild blacklist remove 0226b3ff29216dac187cea393f8af685ad419ac9644e55dce83d145c8b1af213bd#secp256k1 --output json
+```
+
+### Options
+
+```
+  -h, --help            help for remove
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+  -r, --root string   root directory (default "~/.kwild")
+```
+
+### Notes
+
+- Removing a peer from the blacklist does not automatically establish a connection to that peer
+- The peer must still satisfy other connection requirements (whitelist in private mode, available connection slots, etc.)
+- This command works for both manually blacklisted and automatically blacklisted peers
+
+### SEE ALSO
+
+* [kwild blacklist](/docs/ref/kwild/blacklist)	 - Manage a node's peer blacklist
+* [kwild blacklist add](/docs/ref/kwild/blacklist/add)	 - Add a peer to the node's blacklist
+* [kwild blacklist list](/docs/ref/kwild/blacklist/list)	 - List blacklisted peers

--- a/docs/node/reference/index.md
+++ b/docs/node/reference/index.md
@@ -26,6 +26,7 @@ Kwil node and utilities
 ### SEE ALSO
 
 * [kwild admin](/docs/ref/kwild/admin)	 - Administrative commands using the secure admin RPC service
+* [kwild blacklist](/docs/ref/kwild/blacklist)	 - Manage a node's peer blacklist
 * [kwild block](/docs/ref/kwild/block)	 - Leader block execution commands
 * [kwild consensus](/docs/ref/kwild/consensus)	 - Functions for dealing with consensus update proposals
 * [kwild key](/docs/ref/kwild/key)	 - Tools for private key generation and inspection


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/kwil-docs/issues/203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Peer Blacklisting section to P2P configuration with settings for enabling, automatic blacklisting on retry exhaustion, and configurable duration (temporary or permanent), plus operational notes and examples.
  - Added kwild blacklist CLI docs: add (reason/duration), list (text/JSON, detailed fields), and remove commands.
  - Added a dedicated blacklist reference page and updated node reference index to include it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->